### PR TITLE
ci: auto-publish GitHub Release on tag

### DIFF
--- a/.github/workflows/macos-build.yml
+++ b/.github/workflows/macos-build.yml
@@ -2,9 +2,6 @@ name: Build macOS
 
 on:
   workflow_dispatch:
-  push:
-    tags:
-      - 'v*'
   pull_request:
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,79 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  build-windows:
+    name: Build Windows
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Install frontend dependencies
+        run: npm install
+      - name: Build OJ Insight
+        run: npm run tauri build
+      - name: Upload Windows installers
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-windows
+          path: |
+            src-tauri/target/release/bundle/nsis/*.exe
+            src-tauri/target/release/bundle/msi/*.msi
+          if-no-files-found: error
+
+  build-macos:
+    name: Build macOS
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Install frontend dependencies
+        run: npm install
+      - name: Build OJ Insight
+        run: npm run tauri build
+      - name: Zip .app bundle
+        run: |
+          cd src-tauri/target/release/bundle/macos
+          ditto -c -k --sequesterRsrc --keepParent "OJ Insight.app" "OJ Insight.app.zip"
+      - name: Upload macOS installers
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-macos
+          path: |
+            src-tauri/target/release/bundle/dmg/*.dmg
+            src-tauri/target/release/bundle/macos/*.app.zip
+          if-no-files-found: error
+
+  release:
+    name: Publish GitHub Release
+    needs: [build-windows, build-macos]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download release artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: release-assets
+          pattern: release-*
+          merge-multiple: true
+      - name: Publish release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            release-assets/*.exe
+            release-assets/*.msi
+            release-assets/*.dmg
+            release-assets/*.app.zip
+          generate_release_notes: true

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -2,9 +2,6 @@ name: Build Windows
 
 on:
   workflow_dispatch:
-  push:
-    tags:
-      - 'v*'
 
 jobs:
   build-windows:

--- a/BUILD_MACOS.md
+++ b/BUILD_MACOS.md
@@ -7,7 +7,7 @@ OJ Insight 是 Tauri 2 桌面应用。自本版本起支持 macOS（Apple Silico
 1. 打开仓库 `Actions`。
 2. 选择 `Build macOS`。
 3. 点击 `Run workflow`。
-4. 完成后下载 `OJ-Insight-macOS` artifact；推送 `v*` tag 或发起 Pull Request 时 workflow 同样会触发。
+4. 完成后下载 `OJ-Insight-macOS` artifact；推送 `v*` tag 时会触发 `Release` workflow 自动创建 GitHub Release 并上传 DMG 与 `.app.zip`。
 5. 解压后可取得当前 runner 架构的 `OJ Insight_<version>_<arch>.dmg`（如 `aarch64` 或 `x64`）与打包好的 `OJ Insight.app.zip`。
 
 ## 本机开发构建

--- a/BUILD_WINDOWS.md
+++ b/BUILD_WINDOWS.md
@@ -10,7 +10,7 @@ OJ Insight 是 Tauri 2 桌面应用，不再启动 localhost 服务，也不需�
 2. 打开仓库 `Actions`。
 3. 选择 `Build Windows`。
 4. 点击 `Run workflow`。
-5. 完成后下载 `OJ-Insight-Windows` artifact；推送 `v*` tag 时 workflow 还会自动创建 Release。
+5. 完成后下载 `OJ-Insight-Windows` artifact；推送 `v*` tag 时会触发 `Release` workflow 自动创建 GitHub Release 并上传安装包。
 6. 解压后可取得 Windows 构建产物 / 安装包。
 
 ## 本机开发构建

--- a/README.md
+++ b/README.md
@@ -211,21 +211,11 @@ npm run tauri build
 
 ## GitHub Actions 与发布
 
-`.github/workflows/windows-build.yml` 保留：
-
-- `actions/checkout@v5`；
-- `actions/setup-node@v5` + Node 22；
-- Rust stable；
-- Tauri Windows NSIS/MSI 构建；
-- workflow_dispatch 的 artifact；
-- 推送 `v*` tag 时同样触发。
-
-`.github/workflows/macos-build.yml` 提供 macOS 对应构建：
-
-- macos-latest + Rust stable；
-- Tauri `app` + `dmg` 打包（bundle targets 已改为 `all`，按平台自动选择）；
-- 上传 DMG 与 `.app.zip` artifact；
-- workflow_dispatch、`v*` tag 与 Pull Request 均可触发构建。
+- `.github/workflows/windows-build.yml`：手动 `workflow_dispatch` 构建 Windows NSIS/MSI 并上传 artifact。
+- `.github/workflows/macos-build.yml`：手动 `workflow_dispatch` 或 Pull Request 触发 macOS `app` + `dmg` 构建，上传 DMG 与 `.app.zip` artifact。
+- `.github/workflows/release.yml`：推送 `v*` tag 时自动完成 Windows/macOS 构建，并创建/更新 GitHub Release，自动上传：
+  - Windows：`*.exe`、`*.msi`
+  - macOS：`*.dmg`、`OJ Insight.app.zip`
 
 发布前确保下列版本一致：
 
@@ -240,7 +230,9 @@ git tag v0.2.0
 git push origin v0.2.0
 ```
 
-Windows Release 构建使用 `#![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]`，正式版双击不会出现黑色 console 窗口；macOS Release 直接使用 `.app` 应用包。
+Release workflow 会自动创建 GitHub Release 并挂载安装包，无需再从 Actions Artifacts 手动下载上传。
+
+Windows Release 构建仍使用 `#![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]`；macOS Release 直接使用 `.app` 应用包。
 
 ## 数据源边界
 


### PR DESCRIPTION
## What changed

Tag push (`v*`) now automatically builds both platforms and publishes a GitHub Release with all installers attached.

## How it works

- Added `.github/workflows/release.yml`.
  - `build-windows`: builds NSIS `.exe` + MSI `.msi`.
  - `build-macos`: builds `.dmg` + `OJ Insight.app.zip`.
  - `release`: downloads both artifacts and publishes them with `softprops/action-gh-release`, using GitHub auto-generated release notes.
- Removed tag triggers from `windows-build.yml` and `macos-build.yml` to avoid duplicate tag builds:
  - `windows-build.yml`: manual `workflow_dispatch` only.
  - `macos-build.yml`: manual `workflow_dispatch` + `pull_request`.
- Updated README / build docs.

## Usage for maintainers

Just tag and push:

```bash
git tag v0.3.0
git push origin v0.3.0
```

The Release workflow creates the GitHub Release and uploads:

- Windows: `*.exe`, `*.msi`
- macOS: `*.dmg`, `OJ Insight.app.zip`

No need to download Actions artifacts and attach files manually anymore.
