### PR TITLE
fix(xcpc): borrow title string in fallback problem parser

### DIFF
--- a/src-tauri/src/xcpc.rs
+++ b/src-tauri/src/xcpc.rs
@@ -592,7 +592,7 @@ fn parse_category_rows_from_html(html: &str) -> ParsedCategory {
                 index = title_index;
                 title_name
             } else if !title.is_empty() {
-                clean_problem_name(title)
+                clean_problem_name(&title)
             } else {
                 parsed_name
             };


### PR DESCRIPTION
parse_category_rows_from_html built title as a String and passed it directly to clean_problem_name(&str), which failed to compile (E0308).